### PR TITLE
Specify updated models in auto-generated commit message

### DIFF
--- a/.github/workflows/mdrdownload.yml
+++ b/.github/workflows/mdrdownload.yml
@@ -33,4 +33,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add firmware/* mdrdownload.json
-          git diff-index --cached --quiet HEAD -- || (git commit -m "auto download firmware" && git push)
+          updated_service_ids=`git status -s | grep "^A " | awk '{print $2}' | xargs -i sh -c 'basename $(dirname $(dirname {}))' | grep -v "\." | sort -u | sed -z 's/\n/, /g' | sed 's/, $//'`
+          git diff-index --cached --quiet HEAD -- || (git commit -m "Auto download firmware (${updated_service_ids})" && git push)


### PR DESCRIPTION
This pull request changes the auto-generated commit message to include the models (service IDs) which were updated.

Example commit message in case there was one updated model:

> Auto download firmware (2948)

And another example in case there were two updated models:

> Auto download firmware (2948, 2950)

(And if there were no updates, there will be no commit. Just like before.)