### PR TITLE
Fix apktool options in mdrproxy.sh

### DIFF
--- a/security/mdrproxy.sh
+++ b/security/mdrproxy.sh
@@ -33,7 +33,7 @@ if [ "$1" != "nocert" ];then
 fi
 # 解包app
 # unpacking app
-java -jar apktool.jar d --force-all --output SoundConnect --no-src SoundConnect.apk
+java -jar apktool.jar d --force --output SoundConnect --no-src SoundConnect.apk
 # 修改app配置
 # modifying app configuration
 sed 's/android:name="com.sony.songpal.mdr.vim.MdrApplication" /android:name="com.sony.songpal.mdr.vim.MdrApplication" android:networkSecurityConfig="@xml\/network_security_config" /' -i SoundConnect/AndroidManifest.xml
@@ -45,7 +45,7 @@ cp network_security_config.xml SoundConnect/res/xml/network_security_config.xml
 cp mdrproxy-cert.pem SoundConnect/res/raw/mdrproxy_ca.pem
 # 重新打包
 # repacking app
-java -jar apktool.jar b --force-all --output SoundConnect_new.apk SoundConnect
+java -jar apktool.jar b --force --output SoundConnect_new.apk SoundConnect
 # 签名
 # signing
 java -jar uber-apk-signer.jar -a SoundConnect_new.apk


### PR DESCRIPTION
The `--force-all` flag does not exist in the latest versions of apktool. `--force` does.

Output of `apktool` version 2.12.0:
```
Apktool 2.12.0 - a tool for reengineering Android apk files
with smali 3.0.9 and baksmali 3.0.9
Copyright 2010 Ryszard Wiśniewski <brut.alll@gmail.com>
Copyright 2010 Connor Tumbleson <connor.tumbleson@gmail.com>

usage: apktool d|decode [options] <apk-file>
 -f,--force                Force delete destination directory.
 -l,--lib <package:file>   Use shared library <package> located in <file>.
                           Can be specified multiple times.
 -o,--output <dir>         Output decoded files to <dir>. (default: apk.out)
 -p,--frame-path <dir>     Use framework files located in <dir>.
 -r,--no-res               Do not decode resources.
 -s,--no-src               Do not decode sources.
 -t,--frame-tag <tag>      Use framework files tagged with <tag>.

usage: apktool b|build [options] <apk-dir>
 -f,--force                Skip changes detection and build all files.
 -l,--lib <package:file>   Use shared library <package> located in <file>.
                           Can be specified multiple times.
 -o,--output <file>        Output the built apk to <file>. (default: dist/name.apk)
 -p,--frame-path <dir>     Use framework files located in <dir>.
```